### PR TITLE
Replace `volumes` with `networks` in 06-networks.md

### DIFF
--- a/06-networks.md
+++ b/06-networks.md
@@ -29,8 +29,8 @@ networks:
 driver is not available on the platform.
 
 ```yml
-volumes:
-  db-data:
+networks:
+  mynet1:
     driver: overlay
 ```
 
@@ -78,8 +78,8 @@ networks:
 driver-dependent - consult the driver's documentation for more information. Optional.
 
 ```yml
-volumes:
-  db-data:
+networks:
+  mynet1:
     driver_opts:
       foo: "bar"
       baz: 1
@@ -144,8 +144,8 @@ Add metadata to containers using Labels. Can use either an array or a dictionary
 Users should use reverse-DNS notation to prevent labels from conflicting with those used by other software.
 
 ```yml
-volumes:
-  db-data:
+networks:
+  mynet1:
     labels:
       com.example.description: "Financial transaction network"
       com.example.department: "Finance"
@@ -153,8 +153,8 @@ volumes:
 ```
 
 ```yml
-volumes:
-  db-data:
+networks:
+  mynet1:
     labels:
       - "com.example.description=Financial transaction network"
       - "com.example.department=Finance"


### PR DESCRIPTION
Seems the code was incorrectly marking `volumes` instead of `networks` in this section (probably because it is copied from the volume section due to shared element names), causing confusion when reading.

Replace each
```yaml
volumes:
  db-data:
```
with
```yaml
networks:
  mynet1:
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
compose-spec should not evolve without preliminary discussions, so always create an issue before submitting a PR 
-->
Fixes #


